### PR TITLE
Fix URL reference to OpenVehicleDiag repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ J2534 drivers for various Macchina hardware
 
 This is a experimental driver which is built in Rust, and is unofficially ported to Linux and OSX as well as Windows.
 
-The Linux and OSX port can be utilized by [OpenVehicleDiag](github.com/rnd-ash/OpenVehicleDiag)
+The Linux and OSX port can be utilized by [OpenVehicleDiag](https://github.com/rnd-ash/OpenVehicleDiag)
 
 ## Demo videos
 [Odysee](https://odysee.com/@rand_ash:58/openvehiclediag-macchina-j2534-release:4)


### PR DESCRIPTION
GitHub *added* the old to the current and we ended up with this URL:

    https://github.com/FransUrbo/Macchina-J2534/blob/main/github.com/rnd-ash/OpenVehicleDiag

Instead, we need to prefix the URL with https:// to "terminate" it
properly.